### PR TITLE
Added 2.11

### DIFF
--- a/rules.html
+++ b/rules.html
@@ -46,7 +46,7 @@
             <li><b>2.8	Sharing links</b> Malicious links are not allowed. Links that contributes or aid in breaking any of the rules listed on this page are not allowed. Links to adult content is not allowed. Other links are allowed.</li>
             <li><b>2.9  Advertising.</b> Advertising is not allowed unless it’s related to the server. Advertisers will be muted.</li>
             <li><b>2.10	Selling content and services for real money.</b> You are not allowed to sell in-game items or services for real life money.</li>
-            <li><b>2.11 Sending false support tickets and lying to staff.</b> You are not allowed to make fradulent support tickets or lie to staff in support matters. Lying to staff applies to any support matter, whether in support tickets or elsewhere. Sending invalid support tickets is also not allowed as of rule 2.3.</li>
+            <li><b>2.11 Sending false support tickets and lying to staff.</b> You are not allowed to make fraudulent support tickets or lie to staff in support matters. Lying to staff applies to any support matter, whether in support tickets or elsewhere. Sending invalid support tickets is also not allowed as of rule 2.3.</li>
 	</ul>
         </section>
         <section>

--- a/rules.html
+++ b/rules.html
@@ -46,7 +46,8 @@
             <li><b>2.8	Sharing links</b> Malicious links are not allowed. Links that contributes or aid in breaking any of the rules listed on this page are not allowed. Links to adult content is not allowed. Other links are allowed.</li>
             <li><b>2.9  Advertising.</b> Advertising is not allowed unless it’s related to the server. Advertisers will be muted.</li>
             <li><b>2.10	Selling content and services for real money.</b> You are not allowed to sell in-game items or services for real life money.</li>
-        </ul>
+            <li><b>2.11 Sending false support tickets and lying to staff.</b> You are not allowed to make fradulent support tickets or lie to staff in support matters. Lying to staff applies to any support matter, whether in support tickets or elsewhere. Sending invalid support tickets is also not allowed as of rule 2.3.</li>
+	</ul>
         </section>
         <section>
         <h2>3. Griefing</h2>


### PR DESCRIPTION
You are not allowed to make fraudulent support tickets or lie to staff in support matters. Lying to staff applies to any support matter, whether in support tickets or elsewhere. Sending invalid support tickets is also not allowed as of rule 2.3.